### PR TITLE
chore(Jenkins) add Jenkins Core version back in the metadatas

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,4 +1,5 @@
 buildDockerAndPublishImage('jenkins-weekly', [
     automaticSemanticVersioning: true,
     targetplatforms: 'linux/amd64,linux/arm64',
+    nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
 ])


### PR DESCRIPTION
related to https://github.com/jenkins-infra/helpdesk/issues/4171

This PR fixes the version scheme used for the new image (after splitting) by adding metadata suffix and fixing the existing tags and commit messages.

- Main change is cherry-picking (from the repository history) the technique used to tune the `jx-release-version` output to add the metadata (the Jenkins core version in our case) as version scheme suffix

- Also, the change in #1640 showed the new version (as per the default `jx-release-version` command) would be `2.0.0`.
  - But the merge of the PR created a changed commit message which demises this hypothesis, resulting in a `1.49.2` version instead as the `BREAKING CHANGE` footer was not the last line (while `jx-release-version`  expects it).
  - I've removed the generated invalid tags (`1.49.2` and `1.49.3`) on both git and Docker( and their associated GitHub releases as well).
  - I've rewritten the commit history to fix the commit message: https://github.com/jenkins-infra/docker-jenkins-weeklyci/commit/327a859500a42d0f85c9015b5df2d889ebc3e92d
  - This repository setting have been updated to ensure the PR title and body are used as commit message for both Squashed and Merged PRs:

<img width="1111" alt="Capture d’écran 2024-07-15 à 12 11 58" src="https://github.com/user-attachments/assets/c694e7e8-4560-4610-812a-14fb89a14ef4">

----

Expected result:

```shell
echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"
2.0.0-2.466
```