### PR TITLE
chore(Dockerfile) use the new UC for downloading plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,8 @@ FROM jenkins/jenkins:2.471-jdk17
 
 COPY logos /usr/share/jenkins/ref/userContent/logos
 COPY ./plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt --verbose
+RUN jenkins-plugin-cli \
+  --jenkins-update-center='https://azure.updates.jenkins.io/update-center.json' \
+  --jenkins-plugin-info='https://azure.updates.jenkins.io/update-center.json' \
+  --plugin-file /usr/share/jenkins/ref/plugins.txt \
+  --verbose

--- a/bin/update-plugins.sh
+++ b/bin/update-plugins.sh
@@ -29,7 +29,14 @@ for pluginfile in ${list}; do
     if [ -e "${pluginfile}" ]; then
         echo "Updating plugins file: ${pluginfile}"
 
-        java -jar "${TMP_DIR}/jenkins-plugin-manager.jar" -f "${pluginfile}" --available-updates --output txt --war "${TMP_DIR}/jenkins.war"  > plugins2.txt
+        java -jar "${TMP_DIR}/jenkins-plugin-manager.jar" \
+            --plugin-file "${pluginfile}" \
+            --jenkins-update-center='https://azure.updates.jenkins.io/update-center.json' \
+            --jenkins-plugin-info='https://azure.updates.jenkins.io/update-center.json' \
+            --available-updates \
+            --output txt \
+            --war "${TMP_DIR}/jenkins.war" \
+        > plugins2.txt
 
         mv plugins2.txt "${pluginfile}"
     fi


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2283576911

This PR switches both the GHA shell script and the Dockerfile to use the [new `azure.updates.jenkins.io` Update Center](https://github.com/jenkins-infra/helpdesk/issues/2649) as part of the early testing.

The goal for us is to get confidence in using it before planning full scale deployment.