### PR TITLE
chore: use correct UC plugins infos URL - fixup of #1660

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY logos /usr/share/jenkins/ref/userContent/logos
 COPY ./plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli \
   --jenkins-update-center='https://azure.updates.jenkins.io/update-center.json' \
-  --jenkins-plugin-info='https://azure.updates.jenkins.io/update-center.json' \
+  --jenkins-plugin-info='https://azure.updates.jenkins.io/plugin-versions.json' \
   --plugin-file /usr/share/jenkins/ref/plugins.txt \
   --verbose

--- a/bin/update-plugins.sh
+++ b/bin/update-plugins.sh
@@ -32,7 +32,7 @@ for pluginfile in ${list}; do
         java -jar "${TMP_DIR}/jenkins-plugin-manager.jar" \
             --plugin-file "${pluginfile}" \
             --jenkins-update-center='https://azure.updates.jenkins.io/update-center.json' \
-            --jenkins-plugin-info='https://azure.updates.jenkins.io/update-center.json' \
+            --jenkins-plugin-info='https://azure.updates.jenkins.io/plugin-versions.json' \
             --available-updates \
             --output txt \
             --war "${TMP_DIR}/jenkins.war" \


### PR DESCRIPTION
Fix the invalid UC plugins infos URL as per https://github.com/jenkins-infra/docker-jenkins-lts/pull/900#pullrequestreview-2232610072.

Many thanks @timja !